### PR TITLE
refactor: use `unique_ptr` instead of `shared_ptr`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@
 	execution/runtime.cpp
 	execution/interpreter.cpp
 	gc/gc.cpp
+	gc/object.cpp
 	common/cli.cpp
 )
 set(Headers
@@ -18,6 +19,7 @@ set(Headers
 	execution/include/interpreter.hpp
 	gc/include/gc.hpp
 	gc/include/block.hpp
+	gc/include/object.hpp
 
 	common/include/cli.hpp
 	common/include/errors.hpp

--- a/src/execution/evaluator.cpp
+++ b/src/execution/evaluator.cpp
@@ -2,81 +2,79 @@
 #include "include/evaluator.hpp"
 #include <memory>
 
-Evaluator::Evaluator(RuntimeEnvironment& env) : env(env) {};
 
-void Evaluator::evaluate(const std::shared_ptr<ASTBase> ast) {
+void Evaluator::evaluate(ASTBase* ast) {
     switch (ast->type) {
         case ASTType::Program:
-            evaluateProgram(std::static_pointer_cast<ASTProgram>(ast));
+            evaluateProgram(static_cast<ASTProgram*>(ast));
             break;
         case ASTType::FunctionDeclaration:
-            evaluateFunctionDeclaration(std::static_pointer_cast<ASTFunction>(ast));
+            evaluateFunctionDeclaration(static_cast<ASTFunction*>(ast));
             break;
         case ASTType::FunctionCall:
-            evaluateFunctionCall(std::static_pointer_cast<ASTFunctionCall>(ast));
+            evaluateFunctionCall(static_cast<ASTFunctionCall*>(ast));
             break;
         case ASTType::VariableDeclaration:
-            evaluateVariableDeclaration(std::static_pointer_cast<ASTVariableDeclaration>(ast));
+            evaluateVariableDeclaration(static_cast<ASTVariableDeclaration*>(ast));
             break;
         case ASTType::VariableModify:
-            evaluateVariableModify(std::static_pointer_cast<ASTVariableModify>(ast));
+            evaluateVariableModify(static_cast<ASTVariableModify*>(ast));
             break;
         case ASTType::Print:
-            evaluatePrint(std::static_pointer_cast<ASTPrint>(ast));
+            evaluatePrint(static_cast<ASTPrint*>(ast));
             break;
         default:
             throw ZynkError{ ZynkErrorType::RuntimeError, "Unknown AST type." };
     }
 }
 
-void Evaluator::evaluateProgram(const std::shared_ptr<ASTProgram> program) {
+void Evaluator::evaluateProgram(ASTProgram* program) {
     env.enterNewBlock(); // Main program code block.
-    for (const std::shared_ptr<ASTBase>& child : program->body) {
-        evaluate(child);
+    for (const std::unique_ptr<ASTBase>& child : program->body) {
+        evaluate(child.get());
     }
     env.exitCurrentBlock(); // We need to do that, cuz gc need to free memory on main block.
 }
 
-void Evaluator::evaluateFunctionDeclaration(const std::shared_ptr<ASTFunction> function) {
+void Evaluator::evaluateFunctionDeclaration(ASTFunction* function) {
     env.declareFunction(function->name, function);
 }
 
-void Evaluator::evaluateFunctionCall(std::shared_ptr<ASTFunctionCall> functionCall) {
-    const auto func = env.getFunction(functionCall->name);
-
+void Evaluator::evaluateFunctionCall(ASTFunctionCall* functionCall) {
+    ASTFunction* func = env.getFunction(functionCall->name);
     env.enterNewBlock();
-    for (std::shared_ptr<ASTBase> child : func->body) {
-        evaluate(child);
+    for (const std::unique_ptr<ASTBase>& child : func->body) {
+        evaluate(child.get());
     }
     env.exitCurrentBlock();
 }
 
-void Evaluator::evaluatePrint(std::shared_ptr<ASTPrint> print) {
-    const std::string value = evaluateExpression(print->expression);
+void Evaluator::evaluatePrint(ASTPrint* print) {
+    const std::string value = evaluateExpression(print->expression.get());
     std::cout << value << (print->newLine ? "\n" : "");
 }
 
-void Evaluator::evaluateVariableDeclaration(const std::shared_ptr<ASTVariableDeclaration> declaration) {
+void Evaluator::evaluateVariableDeclaration(ASTVariableDeclaration* declaration) {
     env.declareVariable(declaration->name, declaration);
 }
 
-void Evaluator::evaluateVariableModify([[maybe_unused]] const std::shared_ptr<ASTVariableModify> variableModify) {
+void Evaluator::evaluateVariableModify([[maybe_unused]] ASTVariableModify* variableModify) {
     // const auto declaration = env.getVariable(variableModify->name);
     // declaration->value = variableModify->value;
 }
 
-std::string Evaluator::evaluateExpression(const std::shared_ptr<ASTBase> expression) {
+std::string Evaluator::evaluateExpression(ASTBase* expression) {
     switch (expression->type) {
         case ASTType::Value:
-            return std::static_pointer_cast<ASTValue>(expression)->value;
+            return static_cast<ASTValue*>(expression)->value;
         case ASTType::Variable: {
-            const auto var = std::static_pointer_cast<ASTVariable>(expression);
-            return evaluateExpression(env.getVariable(var->name)->value);
+            const auto var = static_cast<ASTVariable*>(expression);
+            return evaluateExpression(env.getVariable(var->name)->value.get());
         };
         case ASTType::BinaryOperation: {
-            const auto operation = std::static_pointer_cast<ASTBinaryOperation>(expression);
-            const std::string left = evaluateExpression(operation->left);
-            const std::string right = evaluateExpression(operation->right);
+            const auto operation = static_cast<ASTBinaryOperation*>(expression);
+            const std::string left = evaluateExpression(operation->left.get());
+            const std::string right = evaluateExpression(operation->right.get());
             try {
                 return calculate<std::string>(left, right, operation->op);
             } catch (const std::invalid_argument&) {

--- a/src/execution/evaluator.cpp
+++ b/src/execution/evaluator.cpp
@@ -1,9 +1,12 @@
 #include "../common/include/errors.hpp"
 #include "include/evaluator.hpp"
 #include <memory>
+#include <cassert>
 
 
 void Evaluator::evaluate(ASTBase* ast) {
+    assert(ast != nullptr && "Ast should not be nullptr");
+
     switch (ast->type) {
         case ASTType::Program:
             evaluateProgram(static_cast<ASTProgram*>(ast));

--- a/src/execution/include/evaluator.hpp
+++ b/src/execution/include/evaluator.hpp
@@ -6,18 +6,16 @@
 
 class Evaluator {
 public:
-    Evaluator(RuntimeEnvironment& env);
-    void evaluate(const std::shared_ptr<ASTBase> ast);
-private:
     RuntimeEnvironment env;
-
-    std::string evaluateExpression(const std::shared_ptr<ASTBase> expression);
-    void evaluateVariableDeclaration(const std::shared_ptr<ASTVariableDeclaration> variable);
-    void evaluateVariableModify(const std::shared_ptr<ASTVariableModify> variableModify);
-    void evaluateProgram(const std::shared_ptr<ASTProgram> program);
-    void evaluateFunctionDeclaration(const std::shared_ptr<ASTFunction> function);
-    void evaluateFunctionCall(const std::shared_ptr<ASTFunctionCall> functionCall);
-    void evaluatePrint(const std::shared_ptr<ASTPrint> print);
+    void evaluate(ASTBase* ast);
+private:
+    std::string evaluateExpression(ASTBase* expression);
+    void evaluateVariableDeclaration(ASTVariableDeclaration* variable);
+    void evaluateVariableModify(ASTVariableModify* variableModify);
+    void evaluateProgram(ASTProgram* program);
+    void evaluateFunctionDeclaration(ASTFunction* function);
+    void evaluateFunctionCall(ASTFunctionCall* functionCall);
+    void evaluatePrint(ASTPrint* print);
 };
 
 template <typename T>

--- a/src/execution/include/runtime.hpp
+++ b/src/execution/include/runtime.hpp
@@ -9,24 +9,22 @@
 
 class RuntimeEnvironment {
 public:
-    RuntimeEnvironment();
     GarbageCollector gc;
 
-    void declareVariable(const std::string& name, const std::shared_ptr<ASTVariableDeclaration> value);
-    std::shared_ptr<ASTVariableDeclaration> getVariable(const std::string& name);
+    void declareVariable(const std::string& name, ASTVariableDeclaration* value);
+    ASTVariableDeclaration* getVariable(const std::string& name);
     bool isVariableDeclared(const std::string& name);
 
-    void declareFunction(const std::string& name, const std::shared_ptr<ASTFunction> func);
-    std::shared_ptr<ASTFunction> getFunction(const std::string& name);
+    void declareFunction(const std::string& name, ASTFunction* func);
+    ASTFunction* getFunction(const std::string& name);
     bool isFunctionDeclared(const std::string& name);
 
-    std::shared_ptr<Block> currentBlock();
+    Block* currentBlock();
     void collectGarbage();
     void enterNewBlock();
     void exitCurrentBlock();
 private:
-    std::shared_ptr<Block> globalBlock;
-    std::stack<std::shared_ptr<Block>> blockStack;
+    std::stack<std::unique_ptr<Block>> blockStack;
 };
 
 #endif // RUNTIME_H

--- a/src/execution/interpreter.cpp
+++ b/src/execution/interpreter.cpp
@@ -17,11 +17,11 @@ void ZynkInterpreter::interpret(const std::string& source) {
 
     // Parsing the tokens into AST objects.
     Parser parser(tokens);
-    const std::shared_ptr<ASTProgram> program = parser.parse();
+    const std::unique_ptr<ASTProgram> program = parser.parse();
     
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-    evaluator.evaluate(program);
+    // Executing the program.
+    Evaluator evaluator;
+    evaluator.evaluate(program.get());
 }
 
 void ZynkInterpreter::interpret_file(const std::string& filePath) {

--- a/src/execution/runtime.cpp
+++ b/src/execution/runtime.cpp
@@ -17,7 +17,7 @@ void RuntimeEnvironment::declareVariable(const std::string& name, ASTVariableDec
     Block* block = currentBlock();
     assert(block != nullptr && "Block should not be nullptr");
 
-    std::unique_ptr<GCObject> gcObject = std::make_unique<GCObject>(value);
+    auto gcObject = std::make_unique<GCObject>(value);
     gc.mark(gcObject.get());
     block->setVariable(name, std::move(gcObject));
 }
@@ -56,7 +56,7 @@ void RuntimeEnvironment::declareFunction(const std::string& name, ASTFunction* f
     Block* block = currentBlock();
     assert(block != nullptr && "Block should not be nullptr");
 
-    std::unique_ptr<GCObject> gcObject = std::make_unique<GCObject>(func);
+    auto gcObject = std::make_unique<GCObject>(func);
     gc.mark(gcObject.get());
     block->setFunction(name, std::move(gcObject));
 }
@@ -105,6 +105,8 @@ void RuntimeEnvironment::exitCurrentBlock() {
     for (const auto& funcPair : block->functions) {
         funcPair.second->unmark();
     }
+    // Keep this block until garbage collection is complete, to ensure that the objects in the block are not destroyed prematurely.
+    std::unique_ptr<Block> blockPtr = std::move(blockStack.top());
     blockStack.pop();
     collectGarbage();
 }

--- a/src/execution/runtime.cpp
+++ b/src/execution/runtime.cpp
@@ -2,32 +2,30 @@
 #include "include/runtime.hpp"
 #include <cassert>
 
-RuntimeEnvironment::RuntimeEnvironment() : globalBlock(std::make_shared<Block>()) {}
-
-std::shared_ptr<Block> RuntimeEnvironment::currentBlock() {
+Block* RuntimeEnvironment::currentBlock() {
     if (blockStack.empty()) return nullptr;
-    return blockStack.top();
+    return blockStack.top().get();
 }
 
-void RuntimeEnvironment::declareVariable(const std::string& name, const std::shared_ptr<ASTVariableDeclaration> value) {
-    if (isVariableDeclared(name)) {
+void RuntimeEnvironment::declareVariable(const std::string& name, ASTVariableDeclaration* value) {
+    if (isVariableDeclared(name)) { // todo: check only for current block.
         throw ZynkError{
             ZynkErrorType::DuplicateDeclarationError,
             "Variable '" + name + "' is already declared."
         };
     }
-    std::shared_ptr<Block> block = currentBlock();
+    Block* block = currentBlock();
     assert(block != nullptr && "Block should not be nullptr");
 
-    std::shared_ptr<GCObject> gcObject = std::make_shared<GCObject>(value);
-    block->setVariable(name, gcObject);
-    gc.mark(gcObject);
+    std::unique_ptr<GCObject> gcObject = std::make_unique<GCObject>(value);
+    block->setVariable(name, std::move(gcObject));
+    gc.mark(gcObject.get());
 }
 
-std::shared_ptr<ASTVariableDeclaration> RuntimeEnvironment::getVariable(const std::string& name) {
-    std::shared_ptr<Block> block = currentBlock();
+ASTVariableDeclaration* RuntimeEnvironment::getVariable(const std::string& name) {
+    Block* block = currentBlock();
     assert(block != nullptr && "Block should not be nullptr");
-    std::shared_ptr<GCObject> gcObject = block->getVariable(name);
+    GCObject* gcObject = block->getVariable(name);
 
     if (gcObject == nullptr) {
         throw ZynkError{
@@ -35,7 +33,7 @@ std::shared_ptr<ASTVariableDeclaration> RuntimeEnvironment::getVariable(const st
             "Variable named '" + name + "' is not defined."
         };
     }
-    return std::static_pointer_cast<ASTVariableDeclaration>(gcObject->value);
+    return static_cast<ASTVariableDeclaration*>(gcObject->value);
 }
 
 bool RuntimeEnvironment::isVariableDeclared(const std::string& name) {
@@ -48,33 +46,33 @@ bool RuntimeEnvironment::isVariableDeclared(const std::string& name) {
     return true;
 }
 
-void RuntimeEnvironment::declareFunction(const std::string& name, const std::shared_ptr<ASTFunction> func) {
+void RuntimeEnvironment::declareFunction(const std::string& name, ASTFunction* func) {
     if (isFunctionDeclared(name)) {
         throw ZynkError{
             ZynkErrorType::DuplicateDeclarationError,
             "Function '" + name + "' is already declared."
         };
     }
-    std::shared_ptr<Block> block = currentBlock();
+    Block* block = currentBlock();
     assert(block != nullptr && "Block should not be nullptr");
 
-    std::shared_ptr<GCObject> gcObject = std::make_shared<GCObject>(func);
-    block->setFunction(name, gcObject);
-    gc.mark(gcObject);
+    std::unique_ptr<GCObject> gcObject = std::make_unique<GCObject>(func);
+    block->setFunction(name, std::move(gcObject));
+    gc.mark(gcObject.get());
 }
 
-std::shared_ptr<ASTFunction> RuntimeEnvironment::getFunction(const std::string& name) {
-    std::shared_ptr<Block> block = currentBlock();
+ASTFunction* RuntimeEnvironment::getFunction(const std::string& name) {
+    Block* block = currentBlock();
     assert(block != nullptr && "Block should not be nullptr");
 
-    std::shared_ptr<GCObject> gcObject = block->getFunction(name);
+    GCObject* gcObject = block->getFunction(name);
     if (gcObject == nullptr) {
         throw ZynkError{
             ZynkErrorType::NotDefinedError,
             "Function named '" + name + "' is not defined."
         };
     }
-    return std::static_pointer_cast<ASTFunction>(gcObject->value);
+    return static_cast<ASTFunction*>(gcObject->value);
 }
 
 bool RuntimeEnvironment::isFunctionDeclared(const std::string& name) {
@@ -92,13 +90,12 @@ void RuntimeEnvironment::collectGarbage() {
 }
 
 void RuntimeEnvironment::enterNewBlock() {
-    std::shared_ptr<Block> newBlock = std::make_shared<Block>(currentBlock());
-    blockStack.push(newBlock);
+    blockStack.push(std::make_unique<Block>(currentBlock()));
 }
 
 void RuntimeEnvironment::exitCurrentBlock() {
     if (blockStack.empty()) return;
-    std::shared_ptr<Block> block = currentBlock();
+    Block* block = currentBlock();
     assert(block != nullptr && "Block should not be nullptr");
     
     // Unmarking all functions / variables in the current block since we don't need them anymore.

--- a/src/execution/runtime.cpp
+++ b/src/execution/runtime.cpp
@@ -18,8 +18,8 @@ void RuntimeEnvironment::declareVariable(const std::string& name, ASTVariableDec
     assert(block != nullptr && "Block should not be nullptr");
 
     std::unique_ptr<GCObject> gcObject = std::make_unique<GCObject>(value);
-    block->setVariable(name, std::move(gcObject));
     gc.mark(gcObject.get());
+    block->setVariable(name, std::move(gcObject));
 }
 
 ASTVariableDeclaration* RuntimeEnvironment::getVariable(const std::string& name) {
@@ -57,8 +57,8 @@ void RuntimeEnvironment::declareFunction(const std::string& name, ASTFunction* f
     assert(block != nullptr && "Block should not be nullptr");
 
     std::unique_ptr<GCObject> gcObject = std::make_unique<GCObject>(func);
-    block->setFunction(name, std::move(gcObject));
     gc.mark(gcObject.get());
+    block->setFunction(name, std::move(gcObject));
 }
 
 ASTFunction* RuntimeEnvironment::getFunction(const std::string& name) {

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -11,7 +11,6 @@ void GarbageCollector::mark(GCObject* obj) {
 void GarbageCollector::sweep() {
     for (auto it = trackingObjects.begin(); it != trackingObjects.end();) {
         if (!(*it)->isMarked()) {
-            delete* it;
             it = trackingObjects.erase(it);
         } else {
             ++it;

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -1,6 +1,7 @@
 #include "include/gc.hpp"
 #include "include/block.hpp"
 #include <iostream>
+#include <cassert>
 
 void GarbageCollector::mark(GCObject* obj) {
     if (!obj) return;
@@ -10,6 +11,7 @@ void GarbageCollector::mark(GCObject* obj) {
 
 void GarbageCollector::sweep() {
     for (auto it = trackingObjects.begin(); it != trackingObjects.end();) {
+        assert(*it != nullptr && "Object should not be nullptr");
         if (!(*it)->isMarked()) {
             it = trackingObjects.erase(it);
         } else {

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -2,22 +2,8 @@
 #include "include/block.hpp"
 #include <iostream>
 
-GCObject::GCObject(const std::shared_ptr<ASTBase> value) : value(value) {}
-
-void GCObject::mark() {
-    marked = true;
-}
-
-void GCObject::unmark() {
-    marked = false;
-}
-
-bool GCObject::isMarked() const {
-    return marked;
-}
-
-void GarbageCollector::mark(const std::shared_ptr<GCObject> obj) {
-    if (!obj || obj->isMarked()) return;
+void GarbageCollector::mark(GCObject* obj) {
+    if (!obj) return;
     obj->mark();
     trackingObjects.insert(obj);
 }
@@ -32,19 +18,19 @@ void GarbageCollector::sweep() {
     }
 }
 
-void GarbageCollector::collectGarbage(const std::shared_ptr<Block> block) {
+void GarbageCollector::collectGarbage(Block* block) {
     markBlock(block); // Mark the current block to avoid deleting the necessary objects.
     sweep(); // Delete objects which are not marked.
 }
 
-void GarbageCollector::markBlock(const std::shared_ptr<Block> block) {
+void GarbageCollector::markBlock(Block* block) {
     if (!block) return;
 
     for (const auto& varPair : block->variables) {
-        mark(varPair.second);
+        mark(varPair.second.get());
     }
     for (const auto& funcPair : block->functions) {
-        mark(funcPair.second);
+        mark(funcPair.second.get());
     }
     if (block->parentBlock) markBlock(block->parentBlock);
 }

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -11,6 +11,7 @@ void GarbageCollector::mark(GCObject* obj) {
 void GarbageCollector::sweep() {
     for (auto it = trackingObjects.begin(); it != trackingObjects.end();) {
         if (!(*it)->isMarked()) {
+            delete* it;
             it = trackingObjects.erase(it);
         } else {
             ++it;

--- a/src/gc/include/block.hpp
+++ b/src/gc/include/block.hpp
@@ -9,31 +9,31 @@ class GCObject;
 
 class Block {
 public:
-    std::unordered_map<std::string, std::shared_ptr<GCObject>> variables;
-    std::unordered_map<std::string, std::shared_ptr<GCObject>> functions;
-    const std::shared_ptr<Block> parentBlock;
+    std::unordered_map<std::string, std::unique_ptr<GCObject>> variables;
+    std::unordered_map<std::string, std::unique_ptr<GCObject>> functions;
+    Block* parentBlock;
 
-    Block(const std::shared_ptr<Block> parent = nullptr) : parentBlock(parent) {}
+    Block(Block* parent = nullptr) : parentBlock(parent) {}
 
-    void setVariable(const std::string& name, const std::shared_ptr<GCObject> value) {
-        variables[name] = value;
+    void setVariable(const std::string& name, std::unique_ptr<GCObject> value) {
+        variables[name] = std::move(value);
     }
 
-    void setFunction(const std::string& name, const std::shared_ptr<GCObject> func) {
-        functions[name] = func;
+    void setFunction(const std::string& name, std::unique_ptr<GCObject> func) {
+        functions[name] = std::move(func);
     }
 
-    std::shared_ptr<GCObject> getVariable(const std::string& name) {
+    GCObject* getVariable(const std::string& name) {
         if (variables.find(name) != variables.end()) {
-            return variables[name];
+            return variables[name].get();
         }
         if (parentBlock) return parentBlock->getVariable(name);
         return nullptr;
     }
 
-    std::shared_ptr<GCObject> getFunction(const std::string& name) {
+    GCObject* getFunction(const std::string& name) {
         if (functions.find(name) != functions.end()) {
-            return functions[name];
+            return functions[name].get();
         }
         if (parentBlock) return parentBlock->getFunction(name);
         return nullptr;

--- a/src/gc/include/gc.hpp
+++ b/src/gc/include/gc.hpp
@@ -1,32 +1,20 @@
 #ifndef GC_H
 #define GC_H
 
-#include "../../parsing/include/ast.hpp"
 #include "block.hpp"
+#include "object.hpp"
 #include <memory>
 #include <unordered_set>
-
-class GCObject {
-private:
-    bool marked = false; // Whether the object is alive and should not be deleted.
-public:
-    GCObject(const std::shared_ptr<ASTBase> value);
-    const std::shared_ptr<ASTBase> value; // Protected value by GCObject.
-
-    void mark();
-    void unmark();
-    bool isMarked() const;
-};
 
 class GarbageCollector {
 private:
     void sweep();
-    void markBlock(const std::shared_ptr<Block> block);
+    void markBlock(Block* block);
 
-    std::unordered_set<std::shared_ptr<GCObject>> trackingObjects;
+    std::unordered_set<GCObject*> trackingObjects;
 public:
-    void collectGarbage(const std::shared_ptr<Block> protectedBlock);
-    void mark(const std::shared_ptr<GCObject> obj);
+    void collectGarbage(Block* protectedBlock);
+    void mark(GCObject* obj);
     size_t size() const;
 };
 

--- a/src/gc/include/object.hpp
+++ b/src/gc/include/object.hpp
@@ -1,0 +1,18 @@
+#ifndef GC_OBJECT_H
+#define GC_OBJECT_H
+
+#include "../../parsing/include/ast.hpp"
+
+class GCObject {
+private:
+    bool marked = false; // Whether the object is alive and should not be deleted.
+public:
+    GCObject(ASTBase* value);
+    ASTBase* value; // Protected value by GCObject.
+
+    void mark();
+    void unmark();
+    bool isMarked() const;
+};
+
+#endif // GC_OBJECT_H

--- a/src/gc/object.cpp
+++ b/src/gc/object.cpp
@@ -1,0 +1,16 @@
+#include "include/object.hpp"
+#include <memory>
+
+GCObject::GCObject(ASTBase* value) : value(value) {}
+
+void GCObject::mark() {
+    marked = true;
+}
+
+void GCObject::unmark() {
+    marked = false;
+}
+
+bool GCObject::isMarked() const {
+    return marked;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,6 @@ int main(int argc, char* argv[]) {
 		std::cout << "Successfully created a new main.zk file." << std::endl;
 		return 0;
 	}
-
 	ZynkInterpreter interpreter;
 	try {
 		interpreter.interpret_file(cli.args.file_path);

--- a/src/parsing/include/ast.hpp
+++ b/src/parsing/include/ast.hpp
@@ -25,14 +25,14 @@ struct ASTBase {
 
 struct ASTProgram : public ASTBase {
     ASTProgram() : ASTBase(ASTType::Program) {}
-    std::vector<std::shared_ptr<ASTBase>> body;
+    std::vector<std::unique_ptr<ASTBase>> body;
 };
 
 struct ASTFunction : public ASTBase {
     ASTFunction(const std::string& name)
         : ASTBase(ASTType::FunctionDeclaration), name(name) {}
     const std::string name;
-    std::vector<std::shared_ptr<ASTBase>> body;
+    std::vector<std::unique_ptr<ASTBase>> body;
 };
 
 struct ASTFunctionCall : public ASTBase {
@@ -41,25 +41,25 @@ struct ASTFunctionCall : public ASTBase {
 };
 
 struct ASTPrint : public ASTBase {
-    ASTPrint(const std::shared_ptr<ASTBase>& expr, bool newLine) :
-        ASTBase(ASTType::Print), newLine(newLine), expression(expr) {}
+    ASTPrint(std::unique_ptr<ASTBase> expr, bool newLine) :
+        ASTBase(ASTType::Print), newLine(newLine), expression(std::move(expr)) {}
     const bool newLine;
-    const std::shared_ptr<ASTBase> expression;
+    std::unique_ptr<ASTBase> expression;
 };
 
 struct ASTVariableDeclaration : public ASTBase {
-    ASTVariableDeclaration(const std::string& name, const std::string& type, const std::shared_ptr<ASTBase>& value)
-        : ASTBase(ASTType::VariableDeclaration), name(name), type(type), value(value) {}
+    ASTVariableDeclaration(const std::string& name, const std::string& type, std::unique_ptr<ASTBase> value)
+        : ASTBase(ASTType::VariableDeclaration), name(name), type(type), value(std::move(value)) {}
     const std::string name;
     const std::string type;
-    std::shared_ptr<ASTBase> value;
+    std::unique_ptr<ASTBase> value;
 };
 
 struct ASTVariableModify : public ASTBase {
-    ASTVariableModify(const std::string& name, const std::shared_ptr<ASTBase>& value)
-        : ASTBase(ASTType::VariableModify), name(name), value(value) {}
+    ASTVariableModify(const std::string& name, std::unique_ptr<ASTBase> value)
+        : ASTBase(ASTType::VariableModify), name(name), value(std::move(value)) {}
     const std::string name;
-    const std::shared_ptr<ASTBase> value;
+    std::unique_ptr<ASTBase> value;
 };
 
 struct ASTValue : public ASTBase {
@@ -73,11 +73,11 @@ struct ASTVariable : public ASTBase {
 };
 
 struct ASTBinaryOperation : public ASTBase {
-    ASTBinaryOperation(const std::shared_ptr<ASTBase>& left, const std::string& op, const std::shared_ptr<ASTBase>& right)
-        : ASTBase(ASTType::BinaryOperation), left(left), op(op), right(right) {}
-    const std::shared_ptr<ASTBase> left;
+    ASTBinaryOperation(std::unique_ptr<ASTBase> left, const std::string& op, std::unique_ptr<ASTBase> right)
+        : ASTBase(ASTType::BinaryOperation), left(std::move(left)), op(op), right(std::move(right)) {}
+    std::unique_ptr<ASTBase> left;
     const std::string op;
-    const std::shared_ptr<ASTBase> right;
+    std::unique_ptr<ASTBase> right;
 };
 
 #endif // AST_H

--- a/src/parsing/include/parser.hpp
+++ b/src/parsing/include/parser.hpp
@@ -18,16 +18,16 @@ private:
 	Token consume(Token expected);
 	Token currentToken() const;
 
-	std::shared_ptr<ASTBase> parseFunctionDeclaration();
-	std::shared_ptr<ASTBase> parseFunctionCall();
-	std::shared_ptr<ASTBase> parseVariableDeclaration();
-	std::shared_ptr<ASTBase> parseVariableModify();
-	std::shared_ptr<ASTBase> parsePrint(bool newLine);
-	std::shared_ptr<ASTBase> parseExpression(int priority);
-	std::shared_ptr<ASTBase> parsePrimaryExpression();
+	std::unique_ptr<ASTBase> parseFunctionDeclaration();
+	std::unique_ptr<ASTBase> parseFunctionCall();
+	std::unique_ptr<ASTBase> parseVariableDeclaration();
+	std::unique_ptr<ASTBase> parseVariableModify();
+	std::unique_ptr<ASTBase> parsePrint(bool newLine);
+	std::unique_ptr<ASTBase> parseExpression(int priority);
+	std::unique_ptr<ASTBase> parsePrimaryExpression();
 public:
 	Parser(const std::vector<Token>& tokens);
-	std::shared_ptr<ASTProgram> parse();
-	std::shared_ptr<ASTBase> parseCurrent();
+	std::unique_ptr<ASTProgram> parse();
+	std::unique_ptr<ASTBase> parseCurrent();
 };
 #endif // PARSER_H

--- a/src/parsing/include/token.hpp
+++ b/src/parsing/include/token.hpp
@@ -9,7 +9,7 @@ enum class TokenType {
     INT, FLOAT, STRING, BOOL, // Types.
 
     ADD, SUBTRACT, MULTIPLY, // Operators.
-    DIVIDE, EQUAL, NOT_EQUAL, EQUALITY, // Equal is =, Equality is ==
+    DIVIDE, ASSIGN, NOT_EQUAL, EQUAL, // Assign is =, Equal is ==
 
     IDENTIFIER, COLON, LBRACE, // Syntax.
     RBRACE, SEMICOLON, LBRACKET,

--- a/src/parsing/lexer.cpp
+++ b/src/parsing/lexer.cpp
@@ -50,9 +50,9 @@ Token Lexer::next() {
         case '(': return Token(TokenType::LBRACKET, "(", currentLine);
         case ')': return Token(TokenType::RBRACKET, ")", currentLine);
         case '=': {
-            if (peek() != '=') return Token(TokenType::EQUAL, "=", currentLine);
+            if (peek() != '=') return Token(TokenType::ASSIGN, "=", currentLine);
             moveForward();
-            return Token(TokenType::EQUALITY, "==", currentLine);
+            return Token(TokenType::EQUAL, "==", currentLine);
         }
         case '!': {
             if (peek() != '=') return Token(TokenType::UNKNOWN, std::string(1, current), currentLine);

--- a/src/parsing/parser.cpp
+++ b/src/parsing/parser.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<ASTBase> Parser::parseCurrent() {
 		case TokenType::IDENTIFIER:
 			moveForward();
 			if (currentToken().type == TokenType::LBRACKET) return parseFunctionCall();
-			if (currentToken().type == TokenType::EQUAL) return parseVariableModify();
+			if (currentToken().type == TokenType::ASSIGN) return parseVariableModify();
 			[[fallthrough]];
 		default:
 			throw ZynkError{ ZynkErrorType::UnknownError, "Notimplemented: " + current.value, &current.line };
@@ -91,7 +91,7 @@ std::unique_ptr<ASTBase> Parser::parseVariableDeclaration() {
 				&currentLine,
 			};
 	}
-	consume({ TokenType::EQUAL, "=", currentLine });
+	consume({ TokenType::ASSIGN, "=", currentLine });
 	auto varDeclaration = std::make_unique<ASTVariableDeclaration>(
 		varName, varType, parseExpression(0)
 	);
@@ -104,7 +104,7 @@ std::unique_ptr<ASTBase> Parser::parseVariableModify() {
 	const Token current = currentToken();
 
 	consume({ TokenType::IDENTIFIER, current.value, current.line});
-	consume({ TokenType::EQUAL, "=", current.line });
+	consume({ TokenType::ASSIGN, "=", current.line });
 	std::unique_ptr<ASTBase> newValue = parseExpression(0);
 	consume({ TokenType::SEMICOLON, ";", current.line });
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,8 +9,8 @@ set(Sources
     test_interpreter.cpp
     test_parser.cpp
     test_evaluator.cpp
-    test_gc.cpp
     test_block.cpp
+    test_gc.cpp
     test_runtime.cpp
 )
 set(GoogleTestVersion v1.15.0)

--- a/tests/test_block.cpp
+++ b/tests/test_block.cpp
@@ -1,94 +1,112 @@
 #include <gtest/gtest.h>
-
 #include "../src/gc/include/block.hpp"
+#include "../src/gc/include/object.hpp"
 #include "../src/parsing/include/ast.hpp"
 
-std::shared_ptr<GCObject> produceGCObject(ASTType astType);
-
 TEST(BlockTest, SetAndGetVariable) {
-    auto block = std::make_shared<Block>();
-    auto obj1 = produceGCObject(ASTType::VariableDeclaration);
-    auto obj2 = produceGCObject(ASTType::VariableDeclaration);
+    auto block = std::make_unique<Block>();
 
-    block->setVariable("var1", obj1);
-    block->setVariable("var2", obj2);
+    auto ast1 = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
+    auto ast2 = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
 
-    ASSERT_EQ(block->getVariable("var1"), obj1);
-    ASSERT_EQ(block->getVariable("var2"), obj2);
+    auto obj1 = std::make_unique<GCObject>(ast1.get());
+    auto obj2 = std::make_unique<GCObject>(ast2.get());
+
+    block->setVariable("var1", std::move(obj1));
+    block->setVariable("var2", std::move(obj2));
+
+    ASSERT_EQ(block->getVariable("var1"), obj1.get());
+    ASSERT_EQ(block->getVariable("var2"), obj2.get());
     ASSERT_EQ(block->getVariable("nonExistentVar"), nullptr);
 }
 
 TEST(BlockTest, SetAndGetFunction) {
-    auto block = std::make_shared<Block>();
-    auto func1 = produceGCObject(ASTType::FunctionDeclaration);
-    auto func2 = produceGCObject(ASTType::FunctionDeclaration);
+    auto block = std::make_unique<Block>();
 
-    block->setFunction("func1", func1);
-    block->setFunction("func2", func2);
+    auto funcAst1 = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
+    auto funcAst2 = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
 
-    ASSERT_EQ(block->getFunction("func1"), func1);
-    ASSERT_EQ(block->getFunction("func2"), func2);
+    auto func1 = std::make_unique<GCObject>(funcAst1.get());
+    auto func2 = std::make_unique<GCObject>(funcAst2.get());
+
+    block->setFunction("func1", std::move(func1));
+    block->setFunction("func2", std::move(func2));
+
+    ASSERT_EQ(block->getFunction("func1"), func1.get());
+    ASSERT_EQ(block->getFunction("func2"), func2.get());
     ASSERT_EQ(block->getFunction("nonExistentFunc"), nullptr);
 }
 
 TEST(BlockTest, GetVariableFromParentBlock) {
-    auto parentBlock = std::make_shared<Block>();
-    auto childBlock = std::make_shared<Block>(parentBlock);
+    auto parentBlock = std::make_unique<Block>();
+    auto childBlock = std::make_unique<Block>(parentBlock.get());
 
-    auto parentVar = produceGCObject(ASTType::VariableDeclaration);
-    auto childVar = produceGCObject(ASTType::VariableDeclaration);
+    auto parentAstVar = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
+    auto childAstVar = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
 
-    parentBlock->setVariable("sharedVar", parentVar);
-    childBlock->setVariable("uniqueVar", childVar);
+    auto parentVar = std::make_unique<GCObject>(parentAstVar.get());
+    auto childVar = std::make_unique<GCObject>(childAstVar.get());
 
-    ASSERT_EQ(childBlock->getVariable("sharedVar"), parentVar);
-    ASSERT_EQ(childBlock->getVariable("uniqueVar"), childVar);
+    parentBlock->setVariable("sharedVar", std::move(parentVar));
+    childBlock->setVariable("uniqueVar", std::move(childVar));
+
+    ASSERT_EQ(childBlock->getVariable("sharedVar"), parentVar.get());
+    ASSERT_EQ(childBlock->getVariable("uniqueVar"), childVar.get());
     ASSERT_EQ(childBlock->getVariable("nonExistentVar"), nullptr);
 }
 
 TEST(BlockTest, GetFunctionFromParentBlock) {
-    auto parentBlock = std::make_shared<Block>();
-    auto childBlock = std::make_shared<Block>(parentBlock);
+    auto parentBlock = std::make_unique<Block>();
+    auto childBlock = std::make_unique<Block>(parentBlock.get());
 
-    auto parentFunc = produceGCObject(ASTType::FunctionDeclaration);
-    auto childFunc = produceGCObject(ASTType::FunctionDeclaration);
+    auto parentFuncAst = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
+    auto childFuncAst = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
 
-    parentBlock->setFunction("sharedFunc", parentFunc);
-    childBlock->setFunction("uniqueFunc", childFunc);
+    auto parentFunc = std::make_unique<GCObject>(parentFuncAst.get());
+    auto childFunc = std::make_unique<GCObject>(childFuncAst.get());
 
-    ASSERT_EQ(childBlock->getFunction("sharedFunc"), parentFunc);
-    ASSERT_EQ(childBlock->getFunction("uniqueFunc"), childFunc);
+    parentBlock->setFunction("sharedFunc", std::move(parentFunc));
+    childBlock->setFunction("uniqueFunc", std::move(childFunc));
+
+    ASSERT_EQ(childBlock->getFunction("sharedFunc"), parentFunc.get());
+    ASSERT_EQ(childBlock->getFunction("uniqueFunc"), childFunc.get());
     ASSERT_EQ(childBlock->getFunction("nonExistentFunc"), nullptr);
 }
 
 TEST(BlockTest, OverrideVariableInChildBlock) {
-    auto parentBlock = std::make_shared<Block>();
-    auto childBlock = std::make_shared<Block>(parentBlock);
+    auto parentBlock = std::make_unique<Block>();
+    auto childBlock = std::make_unique<Block>(parentBlock.get());
 
-    auto parentVar = produceGCObject(ASTType::VariableDeclaration);
-    auto childVar = produceGCObject(ASTType::VariableDeclaration);
+    auto parentAstVar = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
+    auto childAstVar = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
 
-    parentBlock->setVariable("var", parentVar);
-    ASSERT_EQ(childBlock->getVariable("var"), parentVar);
+    auto parentVar = std::make_unique<GCObject>(parentAstVar.get());
+    auto childVar = std::make_unique<GCObject>(childAstVar.get());
 
-    childBlock->setVariable("var", childVar);
+    parentBlock->setVariable("var", std::move(parentVar));
+    ASSERT_EQ(childBlock->getVariable("var"), parentVar.get());
 
-    ASSERT_EQ(childBlock->getVariable("var"), childVar);
-    ASSERT_EQ(parentBlock->getVariable("var"), parentVar);
+    childBlock->setVariable("var", std::move(childVar));
+
+    ASSERT_EQ(childBlock->getVariable("var"), childVar.get());
+    ASSERT_EQ(parentBlock->getVariable("var"), parentVar.get());
 }
 
 TEST(BlockTest, OverrideFunctionInChildBlock) {
-    auto parentBlock = std::make_shared<Block>();
-    auto childBlock = std::make_shared<Block>(parentBlock);
+    auto parentBlock = std::make_unique<Block>();
+    auto childBlock = std::make_unique<Block>(parentBlock.get());
 
-    auto parentFunc = produceGCObject(ASTType::FunctionDeclaration);
-    auto childFunc = produceGCObject(ASTType::FunctionDeclaration);
+    auto parentFuncAst = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
+    auto childFuncAst = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
 
-    parentBlock->setFunction("func", parentFunc);
+    auto parentFunc = std::make_unique<GCObject>(parentFuncAst.get());
+    auto childFunc = std::make_unique<GCObject>(childFuncAst.get());
 
-    ASSERT_EQ(childBlock->getFunction("func"), parentFunc);
-    childBlock->setFunction("func", childFunc);
+    parentBlock->setFunction("func", std::move(parentFunc));
+    ASSERT_EQ(childBlock->getFunction("func"), parentFunc.get());
 
-    ASSERT_EQ(childBlock->getFunction("func"), childFunc);
-    ASSERT_EQ(parentBlock->getFunction("func"), parentFunc);
+    childBlock->setFunction("func", std::move(childFunc));
+
+    ASSERT_EQ(childBlock->getFunction("func"), childFunc.get());
+    ASSERT_EQ(parentBlock->getFunction("func"), parentFunc.get());
 }

--- a/tests/test_block.cpp
+++ b/tests/test_block.cpp
@@ -15,8 +15,8 @@ TEST(BlockTest, SetAndGetVariable) {
     block->setVariable("var1", std::move(obj1));
     block->setVariable("var2", std::move(obj2));
 
-    ASSERT_EQ(block->getVariable("var1"), obj1.get());
-    ASSERT_EQ(block->getVariable("var2"), obj2.get());
+    ASSERT_EQ(block->getVariable("var1")->value, ast1.get());
+    ASSERT_EQ(block->getVariable("var2")->value, ast2.get());
     ASSERT_EQ(block->getVariable("nonExistentVar"), nullptr);
 }
 
@@ -32,8 +32,8 @@ TEST(BlockTest, SetAndGetFunction) {
     block->setFunction("func1", std::move(func1));
     block->setFunction("func2", std::move(func2));
 
-    ASSERT_EQ(block->getFunction("func1"), func1.get());
-    ASSERT_EQ(block->getFunction("func2"), func2.get());
+    ASSERT_EQ(block->getFunction("func1")->value, funcAst1.get());
+    ASSERT_EQ(block->getFunction("func2")->value, funcAst2.get());
     ASSERT_EQ(block->getFunction("nonExistentFunc"), nullptr);
 }
 
@@ -50,8 +50,8 @@ TEST(BlockTest, GetVariableFromParentBlock) {
     parentBlock->setVariable("sharedVar", std::move(parentVar));
     childBlock->setVariable("uniqueVar", std::move(childVar));
 
-    ASSERT_EQ(childBlock->getVariable("sharedVar"), parentVar.get());
-    ASSERT_EQ(childBlock->getVariable("uniqueVar"), childVar.get());
+    ASSERT_EQ(childBlock->getVariable("sharedVar")->value, parentAstVar.get());
+    ASSERT_EQ(childBlock->getVariable("uniqueVar")->value, childAstVar.get());
     ASSERT_EQ(childBlock->getVariable("nonExistentVar"), nullptr);
 }
 
@@ -68,8 +68,8 @@ TEST(BlockTest, GetFunctionFromParentBlock) {
     parentBlock->setFunction("sharedFunc", std::move(parentFunc));
     childBlock->setFunction("uniqueFunc", std::move(childFunc));
 
-    ASSERT_EQ(childBlock->getFunction("sharedFunc"), parentFunc.get());
-    ASSERT_EQ(childBlock->getFunction("uniqueFunc"), childFunc.get());
+    ASSERT_EQ(childBlock->getFunction("sharedFunc")->value, parentFuncAst.get());
+    ASSERT_EQ(childBlock->getFunction("uniqueFunc")->value, childFuncAst.get());
     ASSERT_EQ(childBlock->getFunction("nonExistentFunc"), nullptr);
 }
 
@@ -84,12 +84,12 @@ TEST(BlockTest, OverrideVariableInChildBlock) {
     auto childVar = std::make_unique<GCObject>(childAstVar.get());
 
     parentBlock->setVariable("var", std::move(parentVar));
-    ASSERT_EQ(childBlock->getVariable("var"), parentVar.get());
 
+    ASSERT_EQ(childBlock->getVariable("var")->value, parentAstVar.get());
     childBlock->setVariable("var", std::move(childVar));
 
-    ASSERT_EQ(childBlock->getVariable("var"), childVar.get());
-    ASSERT_EQ(parentBlock->getVariable("var"), parentVar.get());
+    ASSERT_EQ(childBlock->getVariable("var")->value, childAstVar.get());
+    ASSERT_EQ(parentBlock->getVariable("var")->value, parentAstVar.get());
 }
 
 TEST(BlockTest, OverrideFunctionInChildBlock) {
@@ -103,10 +103,9 @@ TEST(BlockTest, OverrideFunctionInChildBlock) {
     auto childFunc = std::make_unique<GCObject>(childFuncAst.get());
 
     parentBlock->setFunction("func", std::move(parentFunc));
-    ASSERT_EQ(childBlock->getFunction("func"), parentFunc.get());
+    ASSERT_EQ(childBlock->getFunction("func")->value, parentFuncAst.get());
 
     childBlock->setFunction("func", std::move(childFunc));
-
-    ASSERT_EQ(childBlock->getFunction("func"), childFunc.get());
-    ASSERT_EQ(parentBlock->getFunction("func"), parentFunc.get());
+    ASSERT_EQ(childBlock->getFunction("func")->value, childFuncAst.get());
+    ASSERT_EQ(parentBlock->getFunction("func")->value, parentFuncAst.get());
 }

--- a/tests/test_evaluator.cpp
+++ b/tests/test_evaluator.cpp
@@ -13,14 +13,11 @@ TEST(EvaluatorTest, EvaluatePrintStatement) {
 
 	Parser parser(tokens);
 	const auto program = parser.parse();
-
-	RuntimeEnvironment env;
-	Evaluator evaluator(env);
-
-	testing::internal::CaptureStdout();
-	evaluator.evaluate(program);
-	const std::string output = testing::internal::GetCapturedStdout();
-	ASSERT_EQ(output, "Hello, World!\n");
+    
+    testing::internal::CaptureStdout();
+    Evaluator evaluator;
+	evaluator.evaluate(program.get());
+	ASSERT_EQ(testing::internal::GetCapturedStdout(), "Hello, World!\n");
 }
 
 TEST(EvaluatorTest, EvaluateVariableDeclarationAndPrint) {
@@ -31,13 +28,10 @@ TEST(EvaluatorTest, EvaluateVariableDeclarationAndPrint) {
 	Parser parser(tokens);
 	const auto program = parser.parse();
 
-	RuntimeEnvironment env;
-	Evaluator evaluator(env);
-
-	testing::internal::CaptureStdout();
-	evaluator.evaluate(program);
-	std::string output = testing::internal::GetCapturedStdout();
-	ASSERT_EQ(output, "42\n");
+    testing::internal::CaptureStdout();
+    Evaluator evaluator;
+	evaluator.evaluate(program.get());
+	ASSERT_EQ(testing::internal::GetCapturedStdout(), "42\n");
 }
 
 TEST(EvaluatorTest, EvaluateFunctionDeclaration) {
@@ -47,16 +41,12 @@ TEST(EvaluatorTest, EvaluateFunctionDeclaration) {
 
 	Parser parser(tokens);
 	const auto program = parser.parse();
-
-	RuntimeEnvironment env;
-	Evaluator evaluator(env);
-
-	evaluator.evaluate(program);
-
+       
+    testing::internal::CaptureStdout();
+    Evaluator evaluator;
+	evaluator.evaluate(program.get());
 	// We do not call the function, so nothing should show up.
-	testing::internal::CaptureStdout();
-	std::string output = testing::internal::GetCapturedStdout();
-	ASSERT_EQ(output, "");
+	ASSERT_EQ(testing::internal::GetCapturedStdout(), "");
 }
 
 TEST(EvaluatorTest, EvaluateFunctionCall) {
@@ -73,13 +63,10 @@ TEST(EvaluatorTest, EvaluateFunctionCall) {
 	Parser parser(tokens);
 	const auto program = parser.parse();
 
-	RuntimeEnvironment env;
-	Evaluator evaluator(env);
-
-	testing::internal::CaptureStdout();
-	evaluator.evaluate(program);
-	std::string output = testing::internal::GetCapturedStdout();
-	ASSERT_EQ(output, "Inside function.\n");
+    testing::internal::CaptureStdout();
+    Evaluator evaluator;
+	evaluator.evaluate(program.get());
+	ASSERT_EQ(testing::internal::GetCapturedStdout(), "Inside function.\n");
 }
 
 TEST(EvaluatorTest, EvaluateNestedFunctionCalls) {
@@ -99,14 +86,10 @@ TEST(EvaluatorTest, EvaluateNestedFunctionCalls) {
 	Parser parser(tokens);
 	const auto program = parser.parse();
 
-	RuntimeEnvironment env;
-	Evaluator evaluator(env);
-
-	testing::internal::CaptureStdout();
-	evaluator.evaluate(program);
-	std::string output = testing::internal::GetCapturedStdout();
-
-	ASSERT_EQ(output, "Outer function\nInside inner function\n");
+    testing::internal::CaptureStdout();
+	Evaluator evaluator;
+	evaluator.evaluate(program.get());
+	ASSERT_EQ(testing::internal::GetCapturedStdout(), "Outer function\nInside inner function\n");
 }
 
 TEST(EvaluatorTest, EvaluateBinaryOperationAddition) {
@@ -117,13 +100,10 @@ TEST(EvaluatorTest, EvaluateBinaryOperationAddition) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-
     testing::internal::CaptureStdout();
-    evaluator.evaluate(program);
-    std::string output = testing::internal::GetCapturedStdout();
-    ASSERT_EQ(output, "8\n");
+    Evaluator evaluator;
+    evaluator.evaluate(program.get());
+    ASSERT_EQ(testing::internal::GetCapturedStdout(), "8\n");
 }
 
 TEST(EvaluatorTest, EvaluateBinaryOperationMultiply) {
@@ -134,13 +114,10 @@ TEST(EvaluatorTest, EvaluateBinaryOperationMultiply) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-
     testing::internal::CaptureStdout();
-    evaluator.evaluate(program);
-    std::string output = testing::internal::GetCapturedStdout();
-    ASSERT_EQ(output, "42\n");
+    Evaluator evaluator;
+    evaluator.evaluate(program.get());
+    ASSERT_EQ(testing::internal::GetCapturedStdout(), "42\n");
 }
 
 TEST(EvaluatorTest, EvaluateBinaryOperationSubtraction) {
@@ -151,13 +128,10 @@ TEST(EvaluatorTest, EvaluateBinaryOperationSubtraction) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-
     testing::internal::CaptureStdout();
-    evaluator.evaluate(program);
-    std::string output = testing::internal::GetCapturedStdout();
-    ASSERT_EQ(output, "6\n");
+    Evaluator evaluator;
+    evaluator.evaluate(program.get());
+    ASSERT_EQ(testing::internal::GetCapturedStdout(), "6\n");
 }
 
 TEST(EvaluatorTest, EvaluateBinaryOperationDivision) {
@@ -168,13 +142,10 @@ TEST(EvaluatorTest, EvaluateBinaryOperationDivision) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-
     testing::internal::CaptureStdout();
-    evaluator.evaluate(program);
-    std::string output = testing::internal::GetCapturedStdout();
-    ASSERT_EQ(output, "3\n");
+    Evaluator evaluator;
+    evaluator.evaluate(program.get());
+    ASSERT_EQ(testing::internal::GetCapturedStdout(), "3\n");
 }
 
 TEST(EvaluatorTest, EvaluateUndefinedFunctionCall) {
@@ -185,9 +156,8 @@ TEST(EvaluatorTest, EvaluateUndefinedFunctionCall) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-    ASSERT_THROW(evaluator.evaluate(program), ZynkError);
+    Evaluator evaluator;
+    ASSERT_THROW(evaluator.evaluate(program.get()), ZynkError);
 }
 
 TEST(EvaluatorTest, EvaluateUndefinedVariableUsage) {
@@ -198,9 +168,8 @@ TEST(EvaluatorTest, EvaluateUndefinedVariableUsage) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-    ASSERT_THROW(evaluator.evaluate(program), ZynkError);
+    Evaluator evaluator;
+    ASSERT_THROW(evaluator.evaluate(program.get()), ZynkError);
 }
 
 TEST(EvaluatorTest, EvaluateFloatVariableDeclarationAndPrint) {
@@ -211,13 +180,10 @@ TEST(EvaluatorTest, EvaluateFloatVariableDeclarationAndPrint) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-
     testing::internal::CaptureStdout();
-    evaluator.evaluate(program);
-    std::string output = testing::internal::GetCapturedStdout();
-    ASSERT_EQ(output, "3.14\n");
+    Evaluator evaluator;
+    evaluator.evaluate(program.get());
+    ASSERT_EQ(testing::internal::GetCapturedStdout(), "3.14\n");
 }
 
 TEST(EvaluatorTest, EvaluateBinaryOperationFloatAddition) {
@@ -228,13 +194,10 @@ TEST(EvaluatorTest, EvaluateBinaryOperationFloatAddition) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-
     testing::internal::CaptureStdout();
-    evaluator.evaluate(program);
-    std::string output = testing::internal::GetCapturedStdout();
-    ASSERT_EQ(output, "4.000000\n");
+    Evaluator evaluator;
+    evaluator.evaluate(program.get());
+    ASSERT_EQ(testing::internal::GetCapturedStdout(), "4.000000\n");
 }
 
 TEST(EvaluatorTest, DuplicateVariableDeclaration) {
@@ -245,9 +208,8 @@ TEST(EvaluatorTest, DuplicateVariableDeclaration) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-    ASSERT_THROW(evaluator.evaluate(program), ZynkError);
+    Evaluator evaluator;
+    ASSERT_THROW(evaluator.evaluate(program.get()), ZynkError);
 }
 
 TEST(EvaluatorTest, DuplicateFunctionDeclaration) {
@@ -261,9 +223,8 @@ TEST(EvaluatorTest, DuplicateFunctionDeclaration) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-    ASSERT_THROW(evaluator.evaluate(program), ZynkError);
+    Evaluator evaluator;
+    ASSERT_THROW(evaluator.evaluate(program.get()), ZynkError);
 }
 
 TEST(EvaluatorTest, EvaluateVariableInExpression) {
@@ -274,13 +235,10 @@ TEST(EvaluatorTest, EvaluateVariableInExpression) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-
     testing::internal::CaptureStdout();
-    evaluator.evaluate(program);
-    std::string output = testing::internal::GetCapturedStdout();
-    ASSERT_EQ(output, "15\n");
+    Evaluator evaluator;
+    evaluator.evaluate(program.get());
+    ASSERT_EQ(testing::internal::GetCapturedStdout(), "15\n");
 }
 
 TEST(EvaluatorTest, EvaluateBinaryOperationFloatMultiplication) {
@@ -291,13 +249,10 @@ TEST(EvaluatorTest, EvaluateBinaryOperationFloatMultiplication) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-
     testing::internal::CaptureStdout();
-    evaluator.evaluate(program);
-    std::string output = testing::internal::GetCapturedStdout();
-    ASSERT_EQ(output, "5.000000\n");
+    Evaluator evaluator;
+    evaluator.evaluate(program.get());
+    ASSERT_EQ(testing::internal::GetCapturedStdout(), "5.000000\n");
 }
 
 TEST(EvaluatorTest, EvaluateDivisionByZero) {
@@ -308,9 +263,8 @@ TEST(EvaluatorTest, EvaluateDivisionByZero) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-    ASSERT_THROW(evaluator.evaluate(program), ZynkError);
+    Evaluator evaluator;
+    ASSERT_THROW(evaluator.evaluate(program.get()), ZynkError);
 }
 
 TEST(EvaluatorTest, EvaluateEmptyProgram) {
@@ -321,11 +275,8 @@ TEST(EvaluatorTest, EvaluateEmptyProgram) {
     Parser parser(tokens);
     const auto program = parser.parse();
 
-    RuntimeEnvironment env;
-    Evaluator evaluator(env);
-
     testing::internal::CaptureStdout();
-    evaluator.evaluate(program);
-    std::string output = testing::internal::GetCapturedStdout();
-    ASSERT_EQ(output, "");
+    Evaluator evaluator;
+    evaluator.evaluate(program.get());
+    ASSERT_EQ(testing::internal::GetCapturedStdout(), "");
 }

--- a/tests/test_gc.cpp
+++ b/tests/test_gc.cpp
@@ -6,7 +6,7 @@
 
 TEST(GarbageCollectorTest, MarkAndSweepDecrementsCorrectly) {
     GarbageCollector gc;
-    std::vector<std::unique_ptr<GCObject>> gcObjects;
+    std::vector<GCObject*> gcObjects;
 
     auto ast1 = std::make_unique<ASTBase>(ASTType::Program);
     auto ast2 = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
@@ -18,13 +18,13 @@ TEST(GarbageCollectorTest, MarkAndSweepDecrementsCorrectly) {
     auto obj3 = std::make_unique<GCObject>(ast3.get());
     auto obj4 = std::make_unique<GCObject>(ast4.get());
 
-    gcObjects.push_back(std::move(obj1));
-    gcObjects.push_back(std::move(obj2));
-    gcObjects.push_back(std::move(obj3));
-    gcObjects.push_back(std::move(obj4));
+    gcObjects.push_back(obj1.get());
+    gcObjects.push_back(obj2.get());
+    gcObjects.push_back(obj3.get());
+    gcObjects.push_back(obj4.get());
 
-    for (std::unique_ptr<GCObject>& obj : gcObjects) {
-        gc.mark(obj.get());
+    for (const auto& objptr : gcObjects) {
+        gc.mark(objptr);
     }
     gc.collectGarbage(nullptr);
     ASSERT_EQ(gc.size(), 4);

--- a/tests/test_gc.cpp
+++ b/tests/test_gc.cpp
@@ -23,7 +23,7 @@ TEST(GarbageCollectorTest, MarkAndSweepDecrementsCorrectly) {
     gcObjects.push_back(std::move(obj3));
     gcObjects.push_back(std::move(obj4));
 
-    for (const auto& obj : gcObjects) {
+    for (std::unique_ptr<GCObject>& obj : gcObjects) {
         gc.mark(obj.get());
     }
     gc.collectGarbage(nullptr);
@@ -34,7 +34,6 @@ TEST(GarbageCollectorTest, MarkAndSweepDecrementsCorrectly) {
 
         gcObjects.back()->unmark();
         gcObjects.pop_back();
-
         gc.collectGarbage(nullptr);
     }
     gc.collectGarbage(nullptr);

--- a/tests/test_gc.cpp
+++ b/tests/test_gc.cpp
@@ -1,44 +1,54 @@
 #include <gtest/gtest.h>
 #include <vector>
 #include "../src/gc/include/gc.hpp"
-
-std::unique_ptr<GCObject> produceGCObject(ASTType astType) {
-    return std::make_unique<GCObject>(std::make_unique<ASTBase>(astType).get());
-}
+#include "../src/gc/include/block.hpp"
+#include "../src/parsing/include/ast.hpp"
 
 TEST(GarbageCollectorTest, MarkAndSweepDecrementsCorrectly) {
     GarbageCollector gc;
     std::vector<std::unique_ptr<GCObject>> gcObjects;
-    gcObjects.push_back(produceGCObject(ASTType::Program));
-    gcObjects.push_back(produceGCObject(ASTType::FunctionDeclaration));
-    gcObjects.push_back(produceGCObject(ASTType::Print));
-    gcObjects.push_back(produceGCObject(ASTType::FunctionCall));
 
-    // Mark all objects.
+    auto ast1 = std::make_unique<ASTBase>(ASTType::Program);
+    auto ast2 = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
+    auto ast3 = std::make_unique<ASTBase>(ASTType::Print);
+    auto ast4 = std::make_unique<ASTBase>(ASTType::FunctionCall);
+
+    auto obj1 = std::make_unique<GCObject>(ast1.get());
+    auto obj2 = std::make_unique<GCObject>(ast2.get());
+    auto obj3 = std::make_unique<GCObject>(ast3.get());
+    auto obj4 = std::make_unique<GCObject>(ast4.get());
+
+    gcObjects.push_back(std::move(obj1));
+    gcObjects.push_back(std::move(obj2));
+    gcObjects.push_back(std::move(obj3));
+    gcObjects.push_back(std::move(obj4));
+
     for (const auto& obj : gcObjects) {
         gc.mark(obj.get());
     }
-    gc.collectGarbage(nullptr); // Initial garbage collection with all objects marked.
+    gc.collectGarbage(nullptr);
+    ASSERT_EQ(gc.size(), 4);
 
     for (int i = 4; i > 0; i--) {
         ASSERT_EQ(gc.size(), i);
 
-        // Unmark the last object in the vector.
         gcObjects.back()->unmark();
         gcObjects.pop_back();
 
-        // Collect garbage after unmarking one object.
         gc.collectGarbage(nullptr);
     }
-
-    gc.collectGarbage(nullptr); // Final garbage collection to ensure the GC is empty.
-    ASSERT_EQ(gc.size(), 0);    // Expect the GC to have no objects left.
+    gc.collectGarbage(nullptr);
+    ASSERT_EQ(gc.size(), 0);
 }
 
 TEST(GarbageCollectorTest, MarkObjectsCorrectly) {
     GarbageCollector gc;
-    auto obj1 = produceGCObject(ASTType::Program);
-    auto obj2 = produceGCObject(ASTType::FunctionDeclaration);
+
+    auto ast1 = std::make_unique<ASTBase>(ASTType::Program);
+    auto ast2 = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
+
+    auto obj1 = std::make_unique<GCObject>(ast1.get());
+    auto obj2 = std::make_unique<GCObject>(ast2.get());
 
     gc.mark(obj1.get());
     ASSERT_TRUE(obj1->isMarked());
@@ -48,7 +58,6 @@ TEST(GarbageCollectorTest, MarkObjectsCorrectly) {
     ASSERT_TRUE(obj2->isMarked());
     ASSERT_EQ(gc.size(), 2);
 
-    // Try to mark obj1 again (should have no effect on size).
     gc.mark(obj1.get());
     ASSERT_TRUE(obj1->isMarked());
     ASSERT_EQ(gc.size(), 2);
@@ -57,22 +66,20 @@ TEST(GarbageCollectorTest, MarkObjectsCorrectly) {
 TEST(GarbageCollectorTest, HandlesNestedBlocksCorrectly) {
     GarbageCollector gc;
 
-    auto block1 = std::make_unique<Block>(); // Parent block
-    auto block2 = std::make_unique<Block>(block1.get()); // Child block
+    auto block1 = std::make_unique<Block>(); // Blok rodzic
+    auto block2 = std::make_unique<Block>(block1.get()); // Blok dziecko
 
-    auto obj1 = produceGCObject(ASTType::Program);
-    auto obj2 = produceGCObject(ASTType::FunctionDeclaration);
+    auto ast1 = std::make_unique<ASTBase>(ASTType::Program);
+    auto ast2 = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
+    auto obj1 = std::make_unique<GCObject>(ast1.get());
+    auto obj2 = std::make_unique<GCObject>(ast2.get());
 
-    // Set variables in different blocks.
     block1->setVariable("var1", std::move(obj1));
     block2->setVariable("var2", std::move(obj2));
-
-    // Collect garbage with block2 as root.
     gc.collectGarbage(block2.get());
 
-    // Check if both objects are marked due to inheritance from block1.
-    ASSERT_TRUE(obj1->isMarked());
-    ASSERT_TRUE(obj2->isMarked());
+    ASSERT_TRUE(block1->getVariable("var1")->isMarked());
+    ASSERT_TRUE(block2->getVariable("var2")->isMarked());
     ASSERT_EQ(gc.size(), 2);
 }
 
@@ -80,28 +87,22 @@ TEST(GarbageCollectorTest, HandlesEmptyBlock) {
     GarbageCollector gc;
     auto emptyBlock = std::make_unique<Block>();
 
-    // Collect garbage on an empty block.
     gc.collectGarbage(emptyBlock.get());
-
-    // Ensure no objects are tracked since block is empty.
     ASSERT_EQ(gc.size(), 0);
 }
 
 TEST(GarbageCollectorTest, HandlesNullBlock) {
     GarbageCollector gc;
 
-    // Collect garbage with a null block.
     gc.collectGarbage(nullptr);
-
-    // Ensure GC is still empty.
     ASSERT_EQ(gc.size(), 0);
 }
 
 TEST(GarbageCollectorTest, RepeatedMarkAndUnmark) {
     GarbageCollector gc;
-    auto obj1 = produceGCObject(ASTType::Program);
+    auto ast1 = std::make_unique<ASTBase>(ASTType::Program);
+    auto obj1 = std::make_unique<GCObject>(ast1.get());
 
-    // Mark and unmark the object multiple times.
     for (int i = 0; i < 5; ++i) {
         gc.mark(obj1.get());
         ASSERT_TRUE(obj1->isMarked());
@@ -115,13 +116,13 @@ TEST(GarbageCollectorTest, RepeatedMarkAndUnmark) {
 
 TEST(GarbageCollectorTest, CollectGarbageWithSomeMarkedObjects) {
     GarbageCollector gc;
-    auto obj1 = produceGCObject(ASTType::Program);
-    auto obj2 = produceGCObject(ASTType::FunctionDeclaration);
+    auto ast1 = std::make_unique<ASTBase>(ASTType::Program);
+    auto ast2 = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
 
-    // Mark only one object.
+    auto obj1 = std::make_unique<GCObject>(ast1.get());
+    auto obj2 = std::make_unique<GCObject>(ast2.get());
+
     gc.mark(obj2.get());
-
-    // Collect garbage and check.
     gc.collectGarbage(nullptr);
     ASSERT_EQ(gc.size(), 1);
     ASSERT_TRUE(obj2->isMarked());
@@ -130,44 +131,49 @@ TEST(GarbageCollectorTest, CollectGarbageWithSomeMarkedObjects) {
 
 TEST(GarbageCollectorTest, MarkAndRetainObjectsInNestedBlocks) {
     GarbageCollector gc;
-    auto block1 = std::make_unique<Block>(); // Parent block
-    auto block2 = std::make_unique<Block>(block1.get()); // Child block
 
-    auto obj1 = produceGCObject(ASTType::VariableDeclaration);
-    auto obj2 = produceGCObject(ASTType::FunctionDeclaration);
+    auto block1 = std::make_unique<Block>(); // Blok rodzic
+    auto block2 = std::make_unique<Block>(block1.get()); // Blok dziecko
+
+    auto ast1 = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
+    auto ast2 = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
+
+    auto obj1 = std::make_unique<GCObject>(ast1.get());
+    auto obj2 = std::make_unique<GCObject>(ast2.get());
 
     block1->setVariable("var", std::move(obj1));
     block2->setFunction("func", std::move(obj2));
 
-    // Mark only obj2.
-    gc.mark(obj2.get());
-
+    gc.mark(block2->getFunction("func"));
     gc.collectGarbage(block2.get());
 
-    // Check if both objects are marked.
-    ASSERT_TRUE(obj1->isMarked());
-    ASSERT_TRUE(obj2->isMarked());
+    ASSERT_TRUE(block1->getVariable("var")->isMarked());
+    ASSERT_TRUE(block2->getFunction("func")->isMarked());
     ASSERT_EQ(gc.size(), 2);
 }
 
 TEST(GarbageCollectorTest, MarkAllObjectsInHierarchicalBlocks) {
     GarbageCollector gc;
-    auto block1 = std::make_unique<Block>(); // Parent block
-    auto block2 = std::make_unique<Block>(block1.get()); // Child block
 
-    auto obj1 = produceGCObject(ASTType::VariableDeclaration);
-    auto obj2 = produceGCObject(ASTType::VariableDeclaration);
-    auto obj3 = produceGCObject(ASTType::VariableDeclaration);
+    auto block1 = std::make_unique<Block>(); // Blok rodzic
+    auto block2 = std::make_unique<Block>(block1.get()); // Blok dziecko
+
+    auto ast1 = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
+    auto ast2 = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
+    auto ast3 = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
+
+    auto obj1 = std::make_unique<GCObject>(ast1.get());
+    auto obj2 = std::make_unique<GCObject>(ast2.get());
+    auto obj3 = std::make_unique<GCObject>(ast3.get());
 
     block1->setVariable("var1", std::move(obj1));
     block1->setVariable("var2", std::move(obj2));
     block2->setVariable("var3", std::move(obj3));
 
     gc.collectGarbage(block2.get());
-
-    ASSERT_TRUE(obj1->isMarked());
-    ASSERT_TRUE(obj2->isMarked());
-    ASSERT_TRUE(obj3->isMarked());
+    ASSERT_TRUE(block1->getVariable("var1")->isMarked());
+    ASSERT_TRUE(block1->getVariable("var2")->isMarked());
+    ASSERT_TRUE(block2->getVariable("var3")->isMarked());
     ASSERT_EQ(gc.size(), 3);
 }
 
@@ -177,10 +183,15 @@ TEST(GarbageCollectorTest, MarkAllObjectsInComplexStructure) {
     auto block2 = std::make_unique<Block>(block1.get());
     auto block3 = std::make_unique<Block>(block2.get());
 
-    auto obj1 = produceGCObject(ASTType::VariableDeclaration);
-    auto obj2 = produceGCObject(ASTType::VariableDeclaration);
-    auto obj3 = produceGCObject(ASTType::VariableDeclaration);
-    auto obj4 = produceGCObject(ASTType::FunctionDeclaration);
+    auto ast1 = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
+    auto ast2 = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
+    auto ast3 = std::make_unique<ASTBase>(ASTType::VariableDeclaration);
+    auto ast4 = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
+
+    auto obj1 = std::make_unique<GCObject>(ast1.get());
+    auto obj2 = std::make_unique<GCObject>(ast2.get());
+    auto obj3 = std::make_unique<GCObject>(ast3.get());
+    auto obj4 = std::make_unique<GCObject>(ast4.get());
 
     block1->setVariable("var1", std::move(obj1));
     block2->setVariable("var2", std::move(obj2));
@@ -188,44 +199,41 @@ TEST(GarbageCollectorTest, MarkAllObjectsInComplexStructure) {
     block3->setFunction("func1", std::move(obj4));
 
     gc.collectGarbage(block3.get());
-
-    // Ensure all objects in the hierarchy are marked.
-    ASSERT_TRUE(obj1->isMarked());
-    ASSERT_TRUE(obj2->isMarked());
-    ASSERT_TRUE(obj3->isMarked());
-    ASSERT_TRUE(obj4->isMarked());
+    ASSERT_TRUE(block1->getVariable("var1")->isMarked());
+    ASSERT_TRUE(block2->getVariable("var2")->isMarked());
+    ASSERT_TRUE(block3->getVariable("var3")->isMarked());
+    ASSERT_TRUE(block3->getFunction("func1")->isMarked());
     ASSERT_EQ(gc.size(), 4);
 }
 
 TEST(GarbageCollectorTest, CollectGarbageWithFunctionObjects) {
     GarbageCollector gc;
+
     auto block1 = std::make_unique<Block>();
     auto block2 = std::make_unique<Block>(block1.get());
 
-    auto func1 = produceGCObject(ASTType::FunctionDeclaration);
-    auto func2 = produceGCObject(ASTType::FunctionDeclaration);
+    auto ast1 = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
+    auto ast2 = std::make_unique<ASTBase>(ASTType::FunctionDeclaration);
 
-    // Add functions to the blocks
+    auto func1 = std::make_unique<GCObject>(ast1.get());
+    auto func2 = std::make_unique<GCObject>(ast2.get());
+
     block1->setFunction("func1", std::move(func1));
     block2->setFunction("func2", std::move(func2));
 
-    // Mark all objects.
     gc.collectGarbage(block2.get());
-
-    ASSERT_TRUE(func1->isMarked());
-    ASSERT_TRUE(func2->isMarked());
+    ASSERT_TRUE(block1->getFunction("func1")->isMarked());
+    ASSERT_TRUE(block2->getFunction("func2")->isMarked());
     ASSERT_EQ(gc.size(), 2);
 
-    func1->unmark();
+    block1->getFunction("func1")->unmark();
     gc.collectGarbage(nullptr);
 
-    ASSERT_FALSE(func1->isMarked());
-    ASSERT_TRUE(func2->isMarked());
+    ASSERT_FALSE(block1->getFunction("func1")->isMarked());
+    ASSERT_TRUE(block2->getFunction("func2")->isMarked());
     ASSERT_EQ(gc.size(), 1);
 
-    func2->unmark();
+    block2->getFunction("func2")->unmark();
     gc.collectGarbage(nullptr);
-
-    // Ensure that all objects are collected
     ASSERT_EQ(gc.size(), 0);
 }

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -175,7 +175,7 @@ TEST(LexerTokenizeTest, EqualityOperator) {
 	size_t operators = 0;
 
 	for (const Token& token : tokens) {
-		if (token.type == TokenType::EQUALITY) operators++;
+		if (token.type == TokenType::EQUAL) operators++;
 	}
 	EXPECT_TRUE(operators == 2);
 	EXPECT_TRUE(tokens.size() == 9);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -5,283 +5,295 @@
 #include "../src/common/include/errors.hpp"
 
 TEST(ParserTest, parseVariableDeclaration) {
-	Lexer lexer("var a: int = 1;");
-	const std::vector<Token> tokens = lexer.tokenize();
-	
-	Parser parser(tokens);
-	const auto program = parser.parse();
-	
-	ASSERT_TRUE(program->type == ASTType::Program);
-	ASSERT_TRUE(program->body.size() == 1);
-	ASSERT_TRUE(program->body.front()->type == ASTType::VariableDeclaration);
+    Lexer lexer("var a: int = 1;");
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	const auto variable = std::static_pointer_cast<ASTVariableDeclaration>(program->body.front());
+    Parser parser(tokens);
+    auto program = parser.parse();
 
-	ASSERT_TRUE(variable->type == "int");
-	ASSERT_TRUE(variable->name == "a");
-	ASSERT_TRUE(std::static_pointer_cast<ASTValue>(variable->value)->value == "1");
+    ASSERT_EQ(program->type, ASTType::Program);
+    ASSERT_EQ(program->body.size(), 1);
+    ASSERT_EQ(program->body.front()->type, ASTType::VariableDeclaration);
+
+    const auto var = static_cast<ASTVariableDeclaration*>(program->body.front().get());
+
+    ASSERT_EQ(var->type, "int");
+    ASSERT_EQ(var->name, "a");
+    const auto value = static_cast<ASTValue*>(var->value.get());
+    ASSERT_NE(value, nullptr);
+    ASSERT_EQ(value->value, "1");
 }
 
 TEST(ParserTest, parseMultipleVariableDeclarations) {
-	Lexer lexer("var a: int = 1;\nvar b: float = 1.0;\n"
-		"var c: bool = true; \nvar d: String = \"Test\";");
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("var a: int = 1;\nvar b: float = 1.0;\n"
+        "var c: bool = true; \nvar d: String = \"Test\";");
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	const auto program = parser.parse();
+    Parser parser(tokens);
+    auto program = parser.parse();
 
-	ASSERT_TRUE(program->type == ASTType::Program);
-	ASSERT_TRUE(program->body.size() == 4);
+    ASSERT_EQ(program->type, ASTType::Program);
+    ASSERT_EQ(program->body.size(), 4);
 
-	for (const std::shared_ptr<ASTBase>& var : program->body) {
-		ASSERT_EQ(var->type, ASTType::VariableDeclaration);
-	}
+    for (const auto& var : program->body) {
+        ASSERT_EQ(var->type, ASTType::VariableDeclaration);
+    }
 }
 
 TEST(ParserTest, parseFunctionDeclaration) {
-	Lexer lexer("def main(){\n    println(10);\n}");
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("def main(){\n    println(10);\n}");
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	const auto program = parser.parse();
+    Parser parser(tokens);
+    auto program = parser.parse();
 
-	ASSERT_TRUE(program->type == ASTType::Program);
-	ASSERT_TRUE(program->body.size() == 1);
-	ASSERT_TRUE(program->body.front()->type == ASTType::FunctionDeclaration);
+    ASSERT_EQ(program->type, ASTType::Program);
+    ASSERT_EQ(program->body.size(), 1);
+    ASSERT_EQ(program->body.front()->type, ASTType::FunctionDeclaration);
 
-	const auto function = std::static_pointer_cast<ASTFunction>(program->body.front());
-	ASSERT_TRUE(function->name == "main");
-	ASSERT_TRUE(function->body.size() == 1);
-	ASSERT_TRUE(function->body.front()->type == ASTType::Print);
+    const auto function = static_cast<ASTFunction*>(program->body.front().get());
+    ASSERT_EQ(function->name, "main");
+    ASSERT_EQ(function->body.size(), 1);
+    ASSERT_EQ(function->body.front()->type, ASTType::Print);
 
-	const auto print = std::static_pointer_cast<ASTPrint>(function->body.front());
-	ASSERT_TRUE(print->newLine);
-	const auto printValue = std::static_pointer_cast<ASTValue>(print->expression);
-	ASSERT_TRUE(printValue->type == ASTType::Value);
-	ASSERT_TRUE(printValue->value == "10");
+    const auto print = static_cast<ASTPrint*>(function->body.front().get());
+    ASSERT_NE(print, nullptr);
+    ASSERT_TRUE(print->newLine);
+    const auto printValue = static_cast<ASTValue*>(print->expression.get());
+    ASSERT_NE(printValue, nullptr);
+    ASSERT_EQ(printValue->value, "10");
 }
 
 TEST(ParserTest, parseEmptyFunction) {
-	Lexer lexer("def main(){\n}");
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("def main(){\n}");
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	const auto program = parser.parse();
+    Parser parser(tokens);
+    auto program = parser.parse();
 
-	ASSERT_TRUE(program->type == ASTType::Program);
-	ASSERT_TRUE(program->body.size() == 1);
-	ASSERT_TRUE(program->body.front()->type == ASTType::FunctionDeclaration);
+    ASSERT_EQ(program->type, ASTType::Program);
+    ASSERT_EQ(program->body.size(), 1);
+    ASSERT_EQ(program->body.front()->type, ASTType::FunctionDeclaration);
 
-	const auto function = std::static_pointer_cast<ASTFunction>(program->body.front());
-	ASSERT_TRUE(function->name == "main");
-	ASSERT_TRUE(function->body.size() == 0);
+    const auto function = static_cast<ASTFunction*>(program->body.front().get());
+    ASSERT_EQ(function->name, "main");
+    ASSERT_EQ(function->body.size(), 0);
 }
 
 TEST(ParserTest, parseVariableDeclarationWithBinaryOperation) {
-	// 'b' is not defined, but parser doesn't have that context.
-	Lexer lexer("var a: float = b + 1.0;");
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("var a: float = b + 1.0;");
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	const auto program = parser.parse();
+    Parser parser(tokens);
+    auto program = parser.parse();
 
-	ASSERT_TRUE(program->type == ASTType::Program);
-	ASSERT_TRUE(program->body.size() == 1);
-	ASSERT_TRUE(program->body.front()->type == ASTType::VariableDeclaration);
+    ASSERT_EQ(program->type, ASTType::Program);
+    ASSERT_EQ(program->body.size(), 1);
+    ASSERT_EQ(program->body.front()->type, ASTType::VariableDeclaration);
 
-	const auto var = std::static_pointer_cast<ASTVariableDeclaration>(program->body.front());
-	ASSERT_TRUE(var->name == "a");
-	ASSERT_TRUE(var->type == "float");
-	const auto operation = std::static_pointer_cast<ASTBinaryOperation>(var->value);
-	ASSERT_TRUE(operation->op == "+");
-	
-	const auto left = std::static_pointer_cast<ASTVariable>(operation->left);
-	const auto right = std::static_pointer_cast<ASTValue>(operation->right);
-	ASSERT_TRUE(left->name == "b" && right->value == "1.0");
+    const auto var = static_cast<ASTVariableDeclaration*>(program->body.front().get());
+    ASSERT_EQ(var->name, "a");
+    ASSERT_EQ(var->type, "float");
+
+    const auto operation = static_cast<ASTBinaryOperation*>(var->value.get());
+    ASSERT_NE(operation, nullptr);
+    ASSERT_EQ(operation->op, "+");
+
+    const auto left = static_cast<ASTVariable*>(operation->left.get());
+    const auto right = static_cast<ASTValue*>(operation->right.get());
+    ASSERT_NE(left, nullptr);
+    ASSERT_NE(right, nullptr);
+    ASSERT_EQ(left->name, "b");
+    ASSERT_EQ(right->value, "1.0");
 }
 
 TEST(ParserTest, parseVariableDeclarationWithComplexExpression) {
-	// 'b' is not defined, but parser doesn't have that context.
-	Lexer lexer("var a: float = 1 + 5 * b;");
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("var a: float = 1 + 5 * b;");
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	const auto program = parser.parse();
+    Parser parser(tokens);
+    auto program = parser.parse();
 
-	ASSERT_TRUE(program->type == ASTType::Program);
-	ASSERT_TRUE(program->body.size() == 1);
-	ASSERT_TRUE(program->body.front()->type == ASTType::VariableDeclaration);
+    ASSERT_EQ(program->type, ASTType::Program);
+    ASSERT_EQ(program->body.size(), 1);
+    ASSERT_EQ(program->body.front()->type, ASTType::VariableDeclaration);
 
-	const auto var = std::static_pointer_cast<ASTVariableDeclaration>(program->body.front());
-	ASSERT_TRUE(var->name == "a");
-	ASSERT_TRUE(var->type == "float");
+    const auto var = static_cast<ASTVariableDeclaration*>(program->body.front().get());
+    ASSERT_EQ(var->name, "a");
+    ASSERT_EQ(var->type, "float");
 
-	const auto operation = std::static_pointer_cast<ASTBinaryOperation>(var->value);
-	ASSERT_TRUE(operation->op == "+");
+    const auto operation = static_cast<ASTBinaryOperation*>(var->value.get());
+    ASSERT_NE(operation, nullptr);
+    ASSERT_EQ(operation->op, "+");
 
-	const auto leftValue = std::static_pointer_cast<ASTValue>(operation->left);
-	const auto rightOperation = std::static_pointer_cast<ASTBinaryOperation>(operation->right);
+    const auto leftValue = static_cast<ASTValue*>(operation->left.get());
+    const auto rightOperation = static_cast<ASTBinaryOperation*>(operation->right.get());
 
-	ASSERT_TRUE(leftValue->value == "1");
-	ASSERT_TRUE(rightOperation->op == "*");
+    ASSERT_NE(leftValue, nullptr);
+    ASSERT_NE(rightOperation, nullptr);
+    ASSERT_EQ(leftValue->value, "1");
+    ASSERT_EQ(rightOperation->op, "*");
 
-	const auto rightLeftValue = std::static_pointer_cast<ASTValue>(rightOperation->left);
-	const auto rightRightVariable = std::static_pointer_cast<ASTVariable>(rightOperation->right);
+    const auto rightLeftValue = static_cast<ASTValue*>(rightOperation->left.get());
+    const auto rightRightVariable = static_cast<ASTVariable*>(rightOperation->right.get());
 
-	ASSERT_TRUE(rightLeftValue->value == "5");
-	ASSERT_TRUE(rightRightVariable->name == "b");
+    ASSERT_NE(rightLeftValue, nullptr);
+    ASSERT_NE(rightRightVariable, nullptr);
+    ASSERT_EQ(rightLeftValue->value, "5");
+    ASSERT_EQ(rightRightVariable->name, "b");
 }
 
 TEST(ParserTest, parsePrintAndPrintlnCalls) {
-	Lexer lexer("print(0);\nprintln(true);");
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("print(0);\nprintln(true);");
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	const auto program = parser.parse();
+    Parser parser(tokens);
+    auto program = parser.parse();
 
-	ASSERT_TRUE(program->type == ASTType::Program);
-	ASSERT_TRUE(program->body.size() == 2);
-	
-	int newLine = 0;
-	for (const std::shared_ptr<ASTBase>& printBase : program->body) {
-		const auto print = std::static_pointer_cast<ASTPrint>(printBase);
-		ASSERT_EQ(print->newLine, newLine);
-		newLine++;
-	}
+    ASSERT_EQ(program->type, ASTType::Program);
+    ASSERT_EQ(program->body.size(), 2);
+
+    int newLine = 0;
+    for (const auto& printBase : program->body) {
+        const auto print = static_cast<ASTPrint*>(printBase.get());
+        ASSERT_NE(print, nullptr);
+        ASSERT_EQ(print->newLine, newLine);
+        newLine++;
+    }
 }
 
 TEST(ParserTest, ShouldThrowSyntaxError) {
-	Lexer lexer("def main()\n}"); // Missing '{'
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("def main()\n}"); // Missing '{'
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	try {
-		parser.parse();
-		FAIL() << "Expected ZynkError thrown.";
-	}
-	catch (const ZynkError& error) {
-		EXPECT_EQ(error.base_type, ZynkErrorType::SyntaxError);
-	}
-	catch (const std::exception& error) {
-		FAIL() << "Unexpected exception type: " << error.what();
-	}
+    Parser parser(tokens);
+    try {
+        parser.parse();
+        FAIL() << "Expected ZynkError thrown.";
+    }
+    catch (const ZynkError& error) {
+        ASSERT_EQ(error.base_type, ZynkErrorType::SyntaxError);
+    }
+    catch (const std::exception& error) {
+        FAIL() << "Unexpected exception type: " << error.what();
+    }
 }
 
 TEST(ParserTest, ShouldThrowInvalidTypeError) {
-	Lexer lexer("var a: abc = 10;"); // Invalid type 'abc'
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("var a: abc = 10;"); // Invalid type 'abc'
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	try {
-		parser.parse();
-		FAIL() << "Expected ZynkError thrown.";
-	}
-	catch (const ZynkError& error) {
-		EXPECT_EQ(error.base_type, ZynkErrorType::InvalidTypeError);
-	}
-	catch (const std::exception& error) {
-		FAIL() << "Unexpected exception type: " << error.what();
-	}
+    Parser parser(tokens);
+    try {
+        parser.parse();
+        FAIL() << "Expected ZynkError thrown.";
+    }
+    catch (const ZynkError& error) {
+        ASSERT_EQ(error.base_type, ZynkErrorType::InvalidTypeError);
+    }
+    catch (const std::exception& error) {
+        FAIL() << "Unexpected exception type: " << error.what();
+    }
 }
 
 TEST(ParserTest, parseFunctionDeclarationWithMissingBracket) {
-	Lexer lexer("def main({\n    println(10);"); // Missing closing bracket
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("def main({\n    println(10);"); // Missing closing bracket
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	try {
-		parser.parse();
-		FAIL() << "Expected ZynkError thrown.";
-	}
-	catch (const ZynkError& error) {
-		EXPECT_EQ(error.base_type, ZynkErrorType::SyntaxError);
-	}
-	catch (const std::exception& error) {
-		FAIL() << "Unexpected exception type: " << error.what();
-	}
+    Parser parser(tokens);
+    try {
+        parser.parse();
+        FAIL() << "Expected ZynkError thrown.";
+    }
+    catch (const ZynkError& error) {
+        ASSERT_EQ(error.base_type, ZynkErrorType::SyntaxError);
+    }
+    catch (const std::exception& error) {
+        FAIL() << "Unexpected exception type: " << error.what();
+    }
 }
 
 TEST(ParserTest, parseFunctionWithInvalidExpression) {
-	Lexer lexer("def main() {\n    println(10 + ;\n}"); // Invalid expression with missing operand
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("def main() {\n    println(10 + ;\n}"); // Invalid expression with missing operand
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	try {
-		parser.parse();
-		FAIL() << "Expected ZynkError thrown.";
-	}
-	catch (const ZynkError& error) {
-		EXPECT_EQ(error.base_type, ZynkErrorType::ExpressionError);
-	}
-	catch (const std::exception& error) {
-		FAIL() << "Unexpected exception type: " << error.what();
-	}
+    Parser parser(tokens);
+    try {
+        parser.parse();
+        FAIL() << "Expected ZynkError thrown.";
+    }
+    catch (const ZynkError& error) {
+        ASSERT_EQ(error.base_type, ZynkErrorType::ExpressionError);
+    }
+    catch (const std::exception& error) {
+        FAIL() << "Unexpected exception type: " << error.what();
+    }
 }
 
 TEST(ParserTest, parseFunctionCallWithExtraTokens) {
-	Lexer lexer("main(10);"); // Extra comma in function call
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("main(10);"); // Extra comma in function call
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	try {
-		parser.parse();
-		FAIL() << "Expected ZynkError thrown.";
-	}
-	catch (const ZynkError& error) {
-		EXPECT_EQ(error.base_type, ZynkErrorType::SyntaxError);
-	}
-	catch (const std::exception& error) {
-		FAIL() << "Unexpected exception type: " << error.what();
-	}
+    Parser parser(tokens);
+    try {
+        parser.parse();
+        FAIL() << "Expected ZynkError thrown.";
+    }
+    catch (const ZynkError& error) {
+        ASSERT_EQ(error.base_type, ZynkErrorType::SyntaxError);
+    }
+    catch (const std::exception& error) {
+        FAIL() << "Unexpected exception type: " << error.what();
+    }
 }
 
 TEST(ParserTest, parseVariableDeclarationWithMissingColon) {
-	Lexer lexer("var a int = 10;"); // Missing colon
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("var a int = 10;"); // Missing colon
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	try {
-		parser.parse();
-		FAIL() << "Expected ZynkError thrown.";
-	}
-	catch (const ZynkError& error) {
-		EXPECT_EQ(error.base_type, ZynkErrorType::SyntaxError);
-	}
-	catch (const std::exception& error) {
-		FAIL() << "Unexpected exception type: " << error.what();
-	}
+    Parser parser(tokens);
+    try {
+        parser.parse();
+        FAIL() << "Expected ZynkError thrown.";
+    }
+    catch (const ZynkError& error) {
+        ASSERT_EQ(error.base_type, ZynkErrorType::SyntaxError);
+    }
+    catch (const std::exception& error) {
+        FAIL() << "Unexpected exception type: " << error.what();
+    }
 }
 
 TEST(ParserTest, parseExpressionWithInvalidOperator) {
-	Lexer lexer("var a: int = 5 $ 10;"); // Invalid operator '$'
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("var a: int = 5 $ 10;"); // Invalid operator '$'
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	try {
-		parser.parse();
-		FAIL() << "Expected ZynkError thrown.";
-	}
-	catch (const ZynkError& error) {
-		EXPECT_EQ(error.base_type, ZynkErrorType::SyntaxError);
-	}
-	catch (const std::exception& error) {
-		FAIL() << "Unexpected exception type: " << error.what();
-	}
+    Parser parser(tokens);
+    try {
+        parser.parse();
+        FAIL() << "Expected ZynkError thrown.";
+    }
+    catch (const ZynkError& error) {
+        ASSERT_EQ(error.base_type, ZynkErrorType::SyntaxError);
+    }
+    catch (const std::exception& error) {
+        FAIL() << "Unexpected exception type: " << error.what();
+    }
 }
 
 TEST(ParserTest, parseStringWithMissingClosingQuote) {
-	Lexer lexer("var a: String = \"Unclosed string;");
-	const std::vector<Token> tokens = lexer.tokenize();
+    Lexer lexer("var a: String = \"Unclosed string;");
+    const std::vector<Token> tokens = lexer.tokenize();
 
-	Parser parser(tokens);
-	try {
-		parser.parse();
-		FAIL() << "Expected ZynkError thrown.";
-	}
-	catch (const ZynkError& error) {
-		EXPECT_EQ(error.base_type, ZynkErrorType::ExpressionError);
-	}
-	catch (const std::exception& error) {
-		FAIL() << "Unexpected exception type: " << error.what();
-	}
+    Parser parser(tokens);
+    try {
+        parser.parse();
+        FAIL() << "Expected ZynkError thrown.";
+    }
+    catch (const ZynkError& error) {
+        ASSERT_EQ(error.base_type, ZynkErrorType::ExpressionError);
+    }
+    catch (const std::exception& error) {
+        FAIL() << "Unexpected exception type: " << error.what();
+    }
 }


### PR DESCRIPTION
This pull request refactors the codebase to use `unique_ptr` instead of `shared_ptr` for memory management.